### PR TITLE
pin django-filter version to less than 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'setuptools',
         'django<1.9rc1',
         'djangorestframework<3.7.0',
-        'django-filter',
+        'django-filter<2.0',
         'Pillow',
         'mock==1.0.1',
     ],


### PR DESCRIPTION
2.0 requires python 3.4 and DRF 3.8 or above